### PR TITLE
add throughput mode

### DIFF
--- a/c2-generic-variables.tf
+++ b/c2-generic-variables.tf
@@ -65,3 +65,10 @@ variable "uid" {
   type = number
   default = 1000
 }
+
+
+variable "throughput_mode" {
+  description = "(Optional) Throughput mode for the file system. Defaults to elastic. Valid values: `bursting`, or `elastic`."
+  type = string
+  default = "elastic"
+}

--- a/c2-generic-variables.tf
+++ b/c2-generic-variables.tf
@@ -71,4 +71,8 @@ variable "throughput_mode" {
   description = "(Optional) Throughput mode for the file system. Defaults to elastic. Valid values: `bursting`, or `elastic`."
   type = string
   default = "elastic"
+  validation {
+    condition     = contains(["bursting", "elastic"], var.throughput_mode)
+    error_message = "Allowed values for throughput_mode are 'bursting' or 'elastic'."
+  }
 }

--- a/c4-01-efs-resource.tf
+++ b/c4-01-efs-resource.tf
@@ -28,6 +28,8 @@ resource "aws_security_group" "efs_allow_access" {
 # Resource: EFS File System
 resource "aws_efs_file_system" "efs_file_system" {
   creation_token = "efs-${var.efs_name}"
+
+  throughput_mode = var.throughput_mode
   tags = {
     Name = "efs-${var.efs_name}"
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new variable `throughput_mode` for optional configuration of the file system's throughput mode, with default set to "elastic".
	- Added the `throughput_mode` attribute to enhance the configuration flexibility of the EFS file system.

- **Bug Fixes**
	- No bug fixes were included in this release. 

- **Documentation**
	- Updated descriptions for the new variable to clarify its valid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->